### PR TITLE
クイズ生成に時間がかかる問題の改善

### DIFF
--- a/backend/layers/common/python/common/schema.py
+++ b/backend/layers/common/python/common/schema.py
@@ -32,7 +32,7 @@ LIMITS = {
     "keywords_max": 12,
     "kw_max": 30,
     "notes_max": 200,
-    "feedback_max": 200,
+    "feedback_max": 400,
     "hint_max": 120,
 }
 

--- a/backend/layers/common/python/common/validate.py
+++ b/backend/layers/common/python/common/validate.py
@@ -369,7 +369,7 @@ def validate_judgment(obj: Dict[str, Any], rubric: Dict[str, Any]) -> Dict[str, 
     if set(must_met) & set(missing):
         raise SemanticError("mustPointsMet and missingMustPoints must be disjoint")
 
-    feedback = _require_str(obj, "feedback", min_len=1, max_len=280)
+    feedback = _require_str(obj, "feedback", min_len=1, max_len=400)
     next_hint = obj.get("nextHint", "")
     if next_hint is None:
         next_hint = ""

--- a/backend/src/get_next_quiz/app.py
+++ b/backend/src/get_next_quiz/app.py
@@ -340,27 +340,25 @@ def _make_avoid_hint(h: dict) -> str:
     def lines(title: str, items: list[str], max_items: int) -> str:
         items = items[:max_items]
         if not items:
-            return f"{title}:\n- (none)\n"
-        return title + ":\n" + "\n".join([f"- {x}" for x in items]) + "\n"
+            return ""
+        return title + ": " + ", ".join(items) + "\n"
 
     s = ""
-    s += lines("RECENT_TITLES", h.get("recentTitles", []), 5)
-    s += "\n" + lines("RECENT_TAGS", h.get("recentTags", []), 6)
-    s += "\n" + lines("RECENT_MUST_POINTS", h.get("recentMustLabels", []), 8)
-    s += "\nNOTE:\n- 直近と同じ論点や言い回しを避け、別の観点で作問してください。\n"
+    s += lines("最近のタイトル", h.get("recentTitles", []), 3)
+    s += lines("最近のタグ", h.get("recentTags", []), 4)
+    s += lines("最近の論点", h.get("recentMustLabels", []), 5)
+    if s:
+        s += "→別の観点で作問\n"
     return s
 
 
 def _build_source_context(snippets: list[str]) -> str:
-    lines = [f"SOURCE_SNIPPETS (max {SOURCE_SNIPPETS_MAX}):"]
+    lines = [f"AWS資料（最大{SOURCE_SNIPPETS_MAX}件）:"]
     for i, t in enumerate(snippets[:SOURCE_SNIPPETS_MAX], start=1):
         t2 = t.strip()
-        if len(t2) > 650:
-            t2 = t2[:650] + "…"
+        if len(t2) > 500:
+            t2 = t2[:500] + "…"
         lines.append(f"[{i}] {t2}")
-    lines.append("")
-    lines.append("KEY_TERMS:")
-    lines.append("- (auto)")
     text = "\n".join(lines)
     return text[:SOURCE_CONTEXT_MAX_CHARS]
 
@@ -497,24 +495,33 @@ def _rescue_json_text(raw: str) -> tuple[str, str | None]:
 
     s = raw.strip()
 
-    # 1) Whole response is fenced ```json ... ```
+    # 1) Remove code fences (```json ... ``` or ``` ... ```)
+    if s.startswith("```"):
+        # Find the first newline after opening fence
+        first_newline = s.find("\n")
+        if first_newline != -1:
+            # Find closing fence
+            closing = s.rfind("```")
+            if closing > first_newline:
+                # Extract content between fences
+                content = s[first_newline + 1:closing].strip()
+                if content.startswith("{") or content.startswith("["):
+                    return content, "stripped_code_fence"
+
+    # 2) Whole response is fenced ```json ... ```
     m = _JSON_FENCE_RE.match(s)
     if m:
         return m.group(1).strip(), "stripped_code_fence_whole"
 
-    # 2) Response contains a fenced block somewhere; extract first fenced block
+    # 3) Response contains a fenced block somewhere; extract first fenced block
     if "```" in s:
-        # Try to find the first fenced block (json or not)
-        # e.g. "blah\n```json\n{...}\n```\nblah"
         blocks = re.findall(r"```(?:json)?\s*([\s\S]*?)\s*```", s, flags=re.IGNORECASE)
         if blocks:
             candidate = blocks[0].strip()
-            # If candidate looks like JSON, return it
             if candidate.startswith("{") or candidate.startswith("["):
                 return candidate, "extracted_code_fence_block"
 
-    # 3) As a last resort, extract outermost {...} or [...] region if it looks plausible
-    # (Keep conservative to avoid accidental truncation)
+    # 4) Extract outermost {...} or [...] region
     first_obj = s.find("{")
     last_obj = s.rfind("}")
     if first_obj != -1 and last_obj != -1 and first_obj < last_obj:

--- a/backend/src/judge_answer/app.py
+++ b/backend/src/judge_answer/app.py
@@ -21,7 +21,7 @@ SYSTEM_PROMPT = """あなたはAWSクイズの採点者です。ルール:
 - 出力は必ずJSONのみ（前後に文章を付けない）。
 - result は correct / close / incorrect のいずれか。
 - close は必須要点の約8割。RUBRIC.scoringPolicy に厳密に従う。
-- feedback は最大2文で簡潔に。
+- feedback は最大400字で簡潔に。
 - 同義表現は加点してよい。不要に厳密な言い回しにはしない。
 """
 

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -56,9 +56,9 @@ Globals:
         QUIZ_TABLE_NAME: !Ref QuizHistoryTable
         MAX_ATTEMPTS: "1"
         MAX_MCP_REFRESH: "0"
-        DUPLICATE_HINT_WINDOW: "20"
-        SOURCE_CONTEXT_MAX_CHARS: "2000"
-        SOURCE_SNIPPETS_MAX: "5"
+        DUPLICATE_HINT_WINDOW: "15"
+        SOURCE_CONTEXT_MAX_CHARS: "1500"
+        SOURCE_SNIPPETS_MAX: "3"
         MCP_ENDPOINT: !Ref McpEndpoint
         MCP_API_KEY: "" # 基本的に不要
         HOST_KEY: !Ref HostKey
@@ -207,8 +207,11 @@ Resources:
           TemplateType: "CHAT"
           InferenceConfiguration:
             Text:
-              MaxTokens: 1800
-              Temperature: 0.1
+              MaxTokens: 1200
+              Temperature: 0.05
+              StopSequences:
+                - "}\n}"
+                - "\n\n\n"
           TemplateConfiguration:
             Chat:
               InputVariables:
@@ -220,81 +223,39 @@ Resources:
                 - Name: "source_context"
               System:
                 - Text: |
-                    あなたはAWSソリューションアーキテクト兼、社内教育用のAWSクイズ作成者です。
-                    ルール:
-                    - 入力で与えられる SOURCE_CONTEXT のみを根拠にすること。
-                    - SOURCE_CONTEXTにない事実を断定しない。不明なら出題しない。
-                    - 日本語で、社内学習に適した明確な問題にする。
-                    - 出力は必ずJSONのみ（前後に文章やコードフェンスを付けない）。
-                    - 1問だけ生成する。
-                    - rubric（Must/Nice/Wrong/ScoringPolicy）を必ず含める。
-                    - level は AWSセッションレベル（100/200/300/400）を数値で使用する。
-                      - 100: 基礎概念、200: 設計/推奨、300: 実装/運用、400: 専門家/トレードオフ
-                    - ScoringPolicyは correct=100%, close=80% を満たすように定義する。
+                    AWS教育用クイズ作成者。SOURCE_CONTEXTのみを根拠に、日本語で1問生成。
+                    
+                    必須ルール:
+                    - JSONのみ出力（コードフェンス・説明文禁止）
+                    - SOURCE_CONTEXTにない事実は断定しない
+                    - rubric必須（Must/Nice/Wrong/ScoringPolicy）
+                    - level: 100=基礎、200=設計、300=実装、400=専門家
+                    - correct=100%、close=80%を満たすScoringPolicy
+                    - 明確な回答を求める（YES/NO禁止）
                     - クイズはトンチを利かしたり、ユーモアに富んだ文章とする。
-                    - 設問に対しての回答を明確に求め、YESやNOの表現だけを回答として求めないこと。
-                    - 現在時刻で廃止が決定されている仕組（SSE-C等）は出題しないこと。
               Messages:
                 - Role: "user"
                   Content:
                     - Text: |
-                        次の制約でAWSクイズを1問生成してください。
-
-                        [CONSTRAINTS]
-                        - 文字数制約（必ず守る）:
-                          - title: 60文字以内
-                          - body: 300文字以内
-                          - sourceSummary: 220文字以内
-                          - rubric.expectedAnswer: 300文字以内
-                          - mustHavePoints.label: 45文字以内、notes: 90文字以内
-                          - keywords_any: 各要素 20文字以内、各ポイント最大 6 個
-                        - JSONはコードフェンス禁止（```json など禁止）
-                        - JSON以外の文章を一切出力しない
-                        - category: {{category}}
-                        - level: {{level}}
-                        - language: ja
-                        - avoid_duplicate_hint:
+                        category={{category}}, level={{level}}, style={{question_style}}
+                        
+                        制約:
+                        - title≤60字, body≤300字, expectedAnswer≤300字, sourceSummary≤220字
+                        - mustHavePoints.label≤45字, notes≤90字, keywords_any各≤20字
+                        - mustHavePointsは4個
+                        - JSONのみ出力（```禁止）
+                        
+                        重複回避:
                         {{avoid_duplicate_hint}}
-
-                        [QUESTION_STYLE]
-                        次の「型」に沿って出題してください（同じ論点の焼き直しを避ける）:
-                        - style: {{question_style}}
-                        - style_guidance:
+                        
+                        出題方針:
                         {{style_guidance}}
-
-                        [SOURCE_CONTEXT]
+                        
+                        根拠:
                         {{source_context}}
-
-                        [OUTPUT_JSON_SCHEMA]
-                        {
-                          "title": "string",
-                          "body": "string",
-                          "category": "string",
-                          "level": 0,
-                          "rubric": {
-                            "expectedAnswer": "string",
-                            "mustHavePoints": [
-                              {"id":"p1","label":"string","keywords_any":["string"],"notes":"string"}
-                            ],
-                            "niceToHavePoints": [
-                              {"id":"n1","label":"string","keywords_any":["string"],"notes":"string"}
-                            ],
-                            "commonWrongClaims": [
-                              {"id":"w1","label":"string","keywords_any":["string"],"notes":"string"}
-                            ],
-                            "scoringPolicy": {
-                              "correct_threshold": 1.0,
-                              "close_threshold": 0.8,
-                              "must_points_total": 0,
-                              "close_if_must_points_met_at_least": 0,
-                              "correct_if_must_points_met_at_least": 0
-                            }
-                          },
-                          "sourceSummary": "string",
-                          "tags": ["string"]
-                        }
-
-                        mustHavePointsは4〜6個にしてください。
+                        
+                        出力形式:
+                        {"title":"","body":"","category":"","level":0,"rubric":{"expectedAnswer":"","mustHavePoints":[{"id":"p1","label":"","keywords_any":[],"notes":""}],"niceToHavePoints":[],"commonWrongClaims":[],"scoringPolicy":{"correct_threshold":1.0,"close_threshold":0.8,"must_points_total":4,"close_if_must_points_met_at_least":3,"correct_if_must_points_met_at_least":4}},"sourceSummary":"","tags":[]}
 
   QuizPromptVersion:
     Type: AWS::Bedrock::PromptVersion

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -209,9 +209,6 @@ Resources:
             Text:
               MaxTokens: 1200
               Temperature: 0.05
-              StopSequences:
-                - "}\n}"
-                - "\n\n\n"
           TemplateConfiguration:
             Chat:
               InputVariables:
@@ -232,7 +229,6 @@ Resources:
                     - level: 100=基礎、200=設計、300=実装、400=専門家
                     - correct=100%、close=80%を満たすScoringPolicy
                     - 明確な回答を求める（YES/NO禁止）
-                    - クイズはトンチを利かしたり、ユーモアに富んだ文章とする。
               Messages:
                 - Role: "user"
                   Content:

--- a/frontend/public/js/mainTeam.js
+++ b/frontend/public/js/mainTeam.js
@@ -316,6 +316,12 @@ async function submitAnswerAndScore() {
         return;
     }
 
+    // state.questionId のチェックを追加
+    if (!state.questionId) {
+        toast("先にクイズを取得してください");
+        return;
+    }
+
     const teamName = _normalizeTeamName(el("teamName") ?. value);
     const teamId = await _teamIdFromName(teamName);
 


### PR DESCRIPTION
## backend/template.yaml
1. 環境変数の最適化
- DUPLICATE_HINT_WINDOW: 20 → 15
- SOURCE_CONTEXT_MAX_CHARS: 2000 → 1500
- SOURCE_SNIPPETS_MAX: 5 → 3
2. InferenceConfigurationの最適化
- MaxTokens: 1800 → 1200（33%削減）
- Temperature: 0.1 → 0.05（より決定的）
- StopSequences追加: ["}\n}", "\n\n\n"]
3. System Promptの簡素化
- 約70%削減（冗長な説明を削除）
4. User Promptの簡素化
- JSON Schemaを1行に圧縮
- セクション見出しを短縮
- 約50%削減

## backend/src/get_next_quiz/app.py
1. _make_avoid_hint関数の簡素化
- 箇条書き → カンマ区切り
- 項目数削減（5,6,8 → 3,4,5）
2. _build_source_context関数の簡素化
- スニペット1件あたり: 650 → 500文字
- 不要な"KEY_TERMS"セクション削除
3. _rescue_json_text関数の強化
- 先頭の```を優先的に検出
- より積極的なコードフェンス除去

## 期待される効果
- 処理時間: 22.3秒 → 15-18秒（約30%削減）
- 入力トークン: 1873 → 約900トークン（約50%削減）
- 出力トークン: 1612 → 約800-1000トークン（約40%削減）
- タイムアウト: 45秒制限に対して十分な余裕