### PR TITLE
Bedrockのクイズ生成に時間がかかる問題を改善

### DIFF
--- a/backend/layers/common/python/common/ddb.py
+++ b/backend/layers/common/python/common/ddb.py
@@ -25,6 +25,64 @@ class QuizRepo:
         resp = self.table.get_item(Key={"QuestionHash": question_hash})
         return resp.get("Item")
 
+    def update_rubric(self, question_hash: str, rubric: dict) -> bool:
+        """
+        指定されたQuestionHashのアイテムにRubricを追加/更新する
+        
+        Args:
+            question_hash: 更新対象のQuestionHash
+            rubric: 保存するrubricデータ
+        
+        Returns:
+            bool: 更新成功時True、アイテムが存在しない場合False
+        """
+        try:
+            self.table.update_item(
+                Key={"QuestionHash": question_hash},
+                UpdateExpression="SET Rubric = :rubric, UpdatedAt = :updated",
+                ConditionExpression="attribute_exists(QuestionHash)",
+                ExpressionAttributeValues={
+                    ":rubric": rubric,
+                    ":updated": now_iso_jst(),
+                },
+            )
+            return True
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
+                return False
+            raise
+
+    def get_by_hash_with_retry(self, question_hash: str, max_retries: int = 5, wait_seconds: float = 3.0) -> dict | None:
+        """
+        Rubricが完成するまで待機してアイテムを取得
+        
+        Args:
+            question_hash: 取得対象のQuestionHash
+            max_retries: 最大リトライ回数
+            wait_seconds: リトライ間隔（秒）
+        
+        Returns:
+            dict | None: アイテム（Rubric完成済み）、またはNone
+        """
+        import time
+        
+        for attempt in range(max_retries + 1):
+            item = self.get_by_hash(question_hash)
+            
+            if not item:
+                return None
+            
+            # Rubricが存在すればOK
+            if item.get("Rubric"):
+                return item
+            
+            # 最後の試行でなければ待機
+            if attempt < max_retries:
+                time.sleep(wait_seconds)
+        
+        # Rubric未完成のまま返す
+        return item
+
     def get_recent_hints(self, limit: int) -> dict:
         """
         直近N件から重複回避ヒントを組み立てる。

--- a/backend/layers/common/python/common/validate.py
+++ b/backend/layers/common/python/common/validate.py
@@ -222,8 +222,8 @@ def _validate_points(points: Any, *, path: str, min_items: int, max_items: int) 
         label2 = _sanitize_text(_strip(label))
         if not label2:
             raise SchemaError(f"{path}[{idx}].label empty")
-        if len(label2) > 60:
-            raise SchemaError(f"{path}[{idx}].label too long (max 60)")
+        if len(label2) > 40:  # 60 → 40に短縮
+            raise SchemaError(f"{path}[{idx}].label too long (max 40)")
 
         notes = p.get("notes")
         if not _is_str(notes):
@@ -231,16 +231,24 @@ def _validate_points(points: Any, *, path: str, min_items: int, max_items: int) 
         notes2 = _sanitize_text(_strip(notes))
         if not notes2:
             raise SchemaError(f"{path}[{idx}].notes empty")
-        if len(notes2) > 120:
-            raise SchemaError(f"{path}[{idx}].notes too long (max 120)")
+        if len(notes2) > 80:  # 120 → 80に短縮
+            raise SchemaError(f"{path}[{idx}].notes too long (max 80)")
 
         keywords_any = _validate_keywords_any(p.get("keywords_any", []), path=f"{path}[{idx}].keywords_any")
+        
+        # keywords_anyの最大長を20文字に制限
+        keywords_any_short = []
+        for kw in keywords_any:
+            if len(kw) > 20:
+                keywords_any_short.append(kw[:20])
+            else:
+                keywords_any_short.append(kw)
 
         out.append(
             {
                 "id": pid2,
                 "label": label2,
-                "keywords_any": keywords_any,
+                "keywords_any": keywords_any_short,
                 "notes": notes2,
             }
         )
@@ -489,6 +497,45 @@ def validate_judgment(obj: Dict[str, Any], rubric: Dict[str, Any]) -> Dict[str, 
 
 # Backward compatibility for british spelling
 validate_judgement = validate_judgment
+
+
+# -----------------------------
+# rubric validator (for separate rubric generation)
+# -----------------------------
+
+def validate_rubric(obj: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Validate rubric-only JSON output from Bedrock.
+    Returns normalized rubric dict.
+    """
+    if not _is_dict(obj):
+        raise SchemaError("Rubric output must be object")
+
+    expected_answer = _require_str(
+        obj,
+        "expectedAnswer",
+        min_len=1,
+        max_len=LIMITS["expected_answer_max"],
+    )
+
+    must_points_raw = _require_list(obj, "mustHavePoints")
+    must_points = _validate_points(must_points_raw, path="mustHavePoints", min_items=4, max_items=6)
+
+    nice_points_raw = obj.get("niceToHavePoints", [])
+    nice_points = _validate_points(nice_points_raw, path="niceToHavePoints", min_items=0, max_items=6) if nice_points_raw else []
+
+    wrong_claims_raw = obj.get("commonWrongClaims", [])
+    wrong_claims = _validate_points(wrong_claims_raw, path="commonWrongClaims", min_items=0, max_items=6) if wrong_claims_raw else []
+
+    scoring_policy = _validate_scoring_policy(_require_key(obj, "scoringPolicy"), must_total=len(must_points))
+
+    return {
+        "expectedAnswer": expected_answer,
+        "mustHavePoints": must_points,
+        "niceToHavePoints": nice_points,
+        "commonWrongClaims": wrong_claims,
+        "scoringPolicy": scoring_policy,
+    }
 
 
 # -----------------------------

--- a/backend/src/generate_rubric/__init__.py
+++ b/backend/src/generate_rubric/__init__.py
@@ -1,0 +1,1 @@
+# Generate Rubric Function

--- a/backend/src/generate_rubric/app.py
+++ b/backend/src/generate_rubric/app.py
@@ -1,0 +1,178 @@
+"""
+Rubric生成関数（非同期実行）
+get_next_quizから呼び出され、バックグラウンドでrubricを生成してDDBに保存
+"""
+from __future__ import annotations
+
+import os
+import json
+from decimal import Decimal
+import boto3
+
+from common.bedrock import BedrockClient
+from common.config import (
+    BEDROCK_MODEL_ID,
+    BEDROCK_GUARDRAIL_IDENTIFIER,
+    BEDROCK_GUARDRAIL_VERSION,
+    QUIZ_TABLE_NAME,
+)
+from common.ddb import QuizRepo
+from common.errors import ParseError, SchemaError, SemanticError
+from common.schema import LIMITS
+from common.validate import parse_json_strict, validate_rubric
+
+
+def _to_ddb_safe(x):
+    """Convert float to Decimal for DynamoDB compatibility"""
+    if isinstance(x, float):
+        return Decimal(str(x))
+    if isinstance(x, dict):
+        return {k: _to_ddb_safe(v) for k, v in x.items()}
+    if isinstance(x, list):
+        return [_to_ddb_safe(v) for v in x]
+    return x
+
+
+def _mask(s: str | None, keep: int = 6) -> str:
+    if not s:
+        return ""
+    s = str(s)
+    if len(s) <= keep:
+        return "*" * len(s)
+    return s[:keep] + "..."
+
+
+def lambda_handler(event, context):
+    """
+    event = {
+        "questionHash": "...",
+        "category": "security",
+        "level": 100,
+        "title": "...",
+        "body": "...",
+        "sourceContext": "...",
+        "requestId": "..."
+    }
+    """
+    try:
+        question_hash = event.get("questionHash")
+        category = event.get("category")
+        level = event.get("level")
+        title = event.get("title")
+        body = event.get("body")
+        source_context = event.get("sourceContext", "")
+        request_id = event.get("requestId", "-")
+
+        print(
+            "[INFO] generate_rubric started",
+            {
+                "requestId": request_id,
+                "questionHash": question_hash,
+                "category": category,
+                "level": level,
+            },
+        )
+
+        if not question_hash or not title or not body:
+            print("[ERROR] Missing required fields")
+            return {"statusCode": 400, "body": "Missing required fields"}
+
+        # Bedrock client
+        brt = boto3.client("bedrock-runtime")
+        bedrock = BedrockClient(
+            brt,
+            BEDROCK_MODEL_ID,
+            guardrail_identifier=BEDROCK_GUARDRAIL_IDENTIFIER if BEDROCK_GUARDRAIL_IDENTIFIER else None,
+            guardrail_version=BEDROCK_GUARDRAIL_VERSION if BEDROCK_GUARDRAIL_IDENTIFIER else None,
+        )
+
+        # Prompt ARN取得
+        rubric_prompt_arn = os.environ.get("BEDROCK_RUBRIC_PROMPT_ARN", "").strip()
+        if not rubric_prompt_arn:
+            print("[ERROR] BEDROCK_RUBRIC_PROMPT_ARN not set")
+            return {"statusCode": 500, "body": "BEDROCK_RUBRIC_PROMPT_ARN not set"}
+
+        print(
+            "[CFG] rubric prompt config",
+            {
+                "requestId": request_id,
+                "BEDROCK_RUBRIC_PROMPT_ARN": _mask(rubric_prompt_arn, 18),
+            },
+        )
+
+        # Prompt変数準備
+        prompt_vars = {
+            "category": str(category),
+            "level": str(level),
+            "title": str(title),
+            "body": str(body),
+            "source_context": str(source_context),
+        }
+
+        # Bedrock呼び出し
+        print("[INFO] Calling Bedrock for rubric generation", {"requestId": request_id})
+        
+        raw = bedrock.converse_prompt_json(
+            prompt_arn=rubric_prompt_arn,
+            prompt_variables=prompt_vars,
+        )
+
+        raw_len = len(raw) if isinstance(raw, str) else -1
+        print(
+            "[INFO] Bedrock returned rubric",
+            {"requestId": request_id, "rawLen": raw_len},
+        )
+
+        # Guardrailブロックチェック
+        if isinstance(raw, str):
+            try:
+                raw_obj = json.loads(raw)
+                if isinstance(raw_obj, dict) and raw_obj.get("error") == "guardrail_blocked":
+                    print(
+                        "[WARN] Guardrail blocked rubric generation",
+                        {"requestId": request_id},
+                    )
+                    return {"statusCode": 200, "body": "Guardrail blocked"}
+            except json.JSONDecodeError:
+                pass
+
+        # JSON解析
+        try:
+            obj = parse_json_strict(raw, LIMITS["raw_json_max"])
+            rubric = validate_rubric(obj)
+        except (ParseError, SchemaError, SemanticError) as e:
+            print(
+                f"[ERROR] rubric validation failed ({e.code}): {e.message}",
+                {"requestId": request_id},
+            )
+            if isinstance(raw, str):
+                print(f"[ERROR] raw(head): {raw[:300]}")
+            return {"statusCode": 400, "body": f"Validation failed: {e.message}"}
+
+        # DDB更新
+        repo = QuizRepo(QUIZ_TABLE_NAME)
+        
+        # Convert float to Decimal for DynamoDB
+        rubric_safe = _to_ddb_safe(rubric)
+        
+        success = repo.update_rubric(question_hash, rubric_safe)
+
+        if success:
+            print(
+                "[INFO] Rubric saved successfully",
+                {"requestId": request_id, "questionHash": question_hash},
+            )
+            return {"statusCode": 200, "body": "Rubric generated and saved"}
+        else:
+            print(
+                "[WARN] Failed to update rubric (item may not exist)",
+                {"requestId": request_id, "questionHash": question_hash},
+            )
+            return {"statusCode": 404, "body": "Question not found"}
+
+    except Exception as e:
+        print("[ERROR] Unexpected exception in generate_rubric")
+        print("[ERROR] repr:", repr(e))
+        import traceback
+        traceback.print_exc()
+        return {"statusCode": 500, "body": "Internal error"}

--- a/backend/src/get_next_quiz/app.py
+++ b/backend/src/get_next_quiz/app.py
@@ -30,10 +30,14 @@ from common.errors import AppError, ParseError, SchemaError, SemanticError
 from common.mcp import McpClient
 from common.normalize import question_hash
 from common.schema import ALLOWED_CATEGORIES, ALLOWED_LEVELS, LIMITS
-from common.validate import parse_json_strict, validate_generation
+from common.validate import parse_json_strict
+
+# Lambda client for async invocation
+_lambda_client = boto3.client('lambda')
 
 # Load JSON schema for structured output
 _QUIZ_SCHEMA = None
+_QUESTION_SCHEMA = None
 
 def _load_quiz_schema() -> dict:
     global _QUIZ_SCHEMA
@@ -42,6 +46,72 @@ def _load_quiz_schema() -> dict:
         with open(schema_path, "r", encoding="utf-8") as f:
             _QUIZ_SCHEMA = json.load(f)
     return _QUIZ_SCHEMA
+
+def _load_question_schema() -> dict:
+    """Load question-only schema (title + body + tags)"""
+    global _QUESTION_SCHEMA
+    if _QUESTION_SCHEMA is None:
+        # Simplified schema for question generation
+        _QUESTION_SCHEMA = {
+            "type": "object",
+            "properties": {
+                "title": {"type": "string", "maxLength": 80},
+                "body": {"type": "string", "maxLength": 300},
+                "category": {"type": "string", "enum": list(ALLOWED_CATEGORIES)},
+                "level": {"type": "integer", "enum": list(ALLOWED_LEVELS)},
+                "sourceSummary": {"type": "string", "maxLength": 250},
+                "tags": {"type": "array", "items": {"type": "string"}}
+            },
+            "required": ["title", "body", "category", "level", "sourceSummary", "tags"],
+            "additionalProperties": False
+        }
+    return _QUESTION_SCHEMA
+
+
+def _validate_question(obj: dict) -> dict:
+    """Validate question-only generation (without rubric)"""
+    from common.validate import _require_str, _require_int, _is_list, _is_str, _sanitize_text, _strip
+    
+    title = _require_str(obj, "title", min_len=1, max_len=LIMITS["title_max"])
+    body = _require_str(obj, "body", min_len=1, max_len=LIMITS["body_max"])
+    
+    category = _require_str(obj, "category", min_len=1, max_len=32)
+    if category not in ALLOWED_CATEGORIES:
+        raise SchemaError(f"category not allowed: {category}")
+    
+    level = _require_int(obj, "level")
+    if level not in ALLOWED_LEVELS:
+        raise SchemaError(f"level not allowed: {level}")
+    
+    source_summary = _require_str(obj, "sourceSummary", min_len=1, max_len=LIMITS["source_summary_max"])
+    
+    tags_raw = obj.get("tags", [])
+    if tags_raw is None:
+        tags_raw = []
+    if not _is_list(tags_raw):
+        raise SchemaError("tags must be list")
+    if len(tags_raw) > 20:
+        raise SchemaError("tags too many items (max 20)")
+    
+    tags = []
+    for i, t in enumerate(tags_raw):
+        if not _is_str(t):
+            raise SchemaError(f"tags[{i}] must be string")
+        t2 = _sanitize_text(_strip(t))
+        if not t2:
+            raise SchemaError(f"tags[{i}] empty")
+        if len(t2) > 40:
+            raise SchemaError(f"tags[{i}] too long (max 40)")
+        tags.append(t2)
+    
+    return {
+        "title": title,
+        "body": body,
+        "category": category,
+        "level": level,
+        "sourceSummary": source_summary,
+        "tags": tags,
+    }
 
 # -----------------------------
 # MCP query components (fast + deterministic diversification)
@@ -390,20 +460,30 @@ def _mask(s: str | None, keep: int = 6) -> str:
     return s[:keep] + "..."
 
 
-def _resolve_effective_prompt_arn(bedrock: BedrockClient, request_id: str) -> str:
-    env_prompt_arn = (BEDROCK_PROMPT_ARN or "").strip()
+def _resolve_effective_prompt_arn(bedrock: BedrockClient, request_id: str, prompt_type: str = "question") -> str:
+    """
+    Resolve effective prompt ARN for question or rubric generation
+    
+    Args:
+        bedrock: BedrockClient instance
+        request_id: Request ID for logging
+        prompt_type: "question" or "rubric" or "full" (legacy)
+    """
+    if prompt_type == "question":
+        env_key = "BEDROCK_QUESTION_PROMPT_ARN"
+    elif prompt_type == "rubric":
+        env_key = "BEDROCK_RUBRIC_PROMPT_ARN"
+    else:  # "full" or legacy
+        env_key = "BEDROCK_PROMPT_ARN"
+    
+    env_prompt_arn = os.environ.get(env_key, "").strip()
     env_prompt_name = (BEDROCK_PROMPT_NAME or "").strip()
 
-    if not env_prompt_arn:
-        env_prompt_arn = (os.environ.get("BEDROCK_PROMPT_ARN") or "").strip()
-    if not env_prompt_name:
-        env_prompt_name = (os.environ.get("BEDROCK_PROMPT_NAME") or "").strip()
-
     print(
-        "[CFG] prompt config",
+        f"[CFG] {prompt_type} prompt config",
         {
             "requestId": request_id,
-            "BEDROCK_PROMPT_ARN": _mask(env_prompt_arn, 18),
+            f"{env_key}": _mask(env_prompt_arn, 18),
             "BEDROCK_PROMPT_NAME": env_prompt_name,
         },
     )
@@ -414,25 +494,25 @@ def _resolve_effective_prompt_arn(bedrock: BedrockClient, request_id: str) -> st
     if not env_prompt_name:
         raise AppError(
             "ConfigError",
-            "Missing BEDROCK_PROMPT_ARN (and BEDROCK_PROMPT_NAME is empty)",
+            f"Missing {env_key} (and BEDROCK_PROMPT_NAME is empty)",
             500,
         )
 
     try:
         resolved = bedrock.resolve_latest_prompt_version_arn(prompt_name=env_prompt_name)
         print(
-            "[INFO] resolved latest prompt version arn",
+            f"[INFO] resolved latest {prompt_type} prompt version arn",
             {"requestId": request_id, "promptArn": _mask(resolved, 18)},
         )
         return resolved
     except Exception as ex:
         print(
-            "[ERROR] failed to resolve latest prompt version arn",
+            f"[ERROR] failed to resolve latest {prompt_type} prompt version arn",
             {"requestId": request_id, "error": repr(ex)},
         )
         raise AppError(
             "ConfigError",
-            "Missing BEDROCK_PROMPT_ARN (and failed to resolve from BEDROCK_PROMPT_NAME)",
+            f"Missing {env_key} (and failed to resolve from BEDROCK_PROMPT_NAME)",
             500,
         )
 
@@ -544,7 +624,7 @@ def lambda_handler(event, context):
 
         mcp = McpClient(MCP_ENDPOINT, MCP_API_KEY)
 
-        effective_prompt_arn = _resolve_effective_prompt_arn(bedrock, aws_request_id)
+        effective_prompt_arn = _resolve_effective_prompt_arn(bedrock, aws_request_id, "question")
 
         hints = repo.get_recent_hints(DUPLICATE_HINT_WINDOW)
         avoid_hint = _make_avoid_hint(hints)
@@ -589,9 +669,7 @@ def lambda_handler(event, context):
                     "source_context": str(source_context),
                 }
 
-                # Note: Structured Output is not supported with Prompt Management
-                # Using optimized prompt instead
-                
+                # Generate question only (title + body + tags)
                 raw = bedrock.converse_prompt_json(
                     prompt_arn=effective_prompt_arn,
                     prompt_variables=prompt_vars,
@@ -599,7 +677,7 @@ def lambda_handler(event, context):
 
                 raw_len = len(raw) if isinstance(raw, str) else -1
                 print(
-                    "[INFO] Bedrock returned (structured output)",
+                    "[INFO] Bedrock returned question (title+body)",
                     {"requestId": aws_request_id, "refresh": refresh, "attempt": attempt, "rawLen": raw_len},
                 )
 
@@ -616,11 +694,10 @@ def lambda_handler(event, context):
                         pass
 
                 try:
-                    # Structured Outputなのでコードフェンス救済は不要（念のため残す）
                     cleaned, reason = _rescue_json_text(raw if isinstance(raw, str) else "")
                     if reason:
                         print(
-                            "[INFO] rescued json text (should not happen with structured output)",
+                            "[INFO] rescued json text",
                             {
                                 "requestId": aws_request_id,
                                 "refresh": refresh,
@@ -629,7 +706,7 @@ def lambda_handler(event, context):
                             },
                         )
                     obj = parse_json_strict(cleaned if reason else raw, LIMITS["raw_json_max"])
-                    quiz = validate_generation(obj)
+                    question = _validate_question(obj)  # Validate question only
                 except (ParseError, SchemaError, SemanticError) as e:
                     print(
                         f"[WARN] generation failed ({e.code}): {e.message}",
@@ -639,25 +716,16 @@ def lambda_handler(event, context):
                         print(f"[WARN] raw(head): {raw[:300]}")
                     continue
 
-                safe_title = _sanitize_for_hash(quiz["title"])
-                safe_body = _sanitize_for_hash(quiz["body"])
-                safe_must_points = []
-                for p in quiz["rubric"]["mustHavePoints"]:
-                    safe_must_points.append(
-                        {
-                            "id": _sanitize_for_hash(p.get("id", "")),
-                            "label": _sanitize_for_hash(p.get("label", "")),
-                            "notes": _sanitize_for_hash(p.get("notes", "")),
-                            "keywords_any": [_sanitize_for_hash(x) for x in (p.get("keywords_any") or [])],
-                        }
-                    )
-
+                safe_title = _sanitize_for_hash(question["title"])
+                safe_body = _sanitize_for_hash(question["body"])
+                
+                # Generate temporary hash without rubric (will be same as final hash since rubric not used in hash)
                 qhash = question_hash(
-                    category=quiz["category"],
-                    level=int(quiz["level"]),
+                    category=question["category"],
+                    level=int(question["level"]),
                     title=safe_title,
                     body=safe_body,
-                    must_points=safe_must_points,
+                    must_points=[],  # No rubric yet
                 )
 
                 created_at = now_iso_jst()
@@ -667,11 +735,11 @@ def lambda_handler(event, context):
                     "GSI1PK": "RECENT",
                     "GSI1SK": created_at,
                     "Version": 1,
-                    "Category": quiz["category"],
-                    "Level": int(quiz["level"]),
+                    "Category": question["category"],
+                    "Level": int(question["level"]),
                     "Language": "ja",
-                    "Question": {"Title": quiz["title"], "Body": quiz["body"]},
-                    "Rubric": quiz["rubric"],
+                    "Question": {"Title": question["title"], "Body": question["body"]},
+                    # Rubric will be added later by GenerateRubricFunction
                     "SourceContext": {
                         "Provider": "aws-knowledge-mcp",
                         "RetrievedAt": created_at,
@@ -681,7 +749,7 @@ def lambda_handler(event, context):
                         ],
                     },
                     "CreatedAt": created_at,
-                    "Tags": quiz["tags"],
+                    "Tags": question["tags"],
                 }
 
                 item = _to_ddb_safe(item)
@@ -707,6 +775,35 @@ def lambda_handler(event, context):
                 )
 
                 if ok:
+                    # Invoke GenerateRubricFunction asynchronously
+                    generate_rubric_function = os.environ.get('GENERATE_RUBRIC_FUNCTION_NAME')
+                    if generate_rubric_function:
+                        try:
+                            rubric_payload = {
+                                "questionHash": qhash,
+                                "category": question["category"],
+                                "level": question["level"],
+                                "title": question["title"],
+                                "body": question["body"],
+                                "sourceContext": source_context,
+                                "requestId": aws_request_id,
+                            }
+                            _lambda_client.invoke(
+                                FunctionName=generate_rubric_function,
+                                InvocationType='Event',  # Async
+                                Payload=json.dumps(rubric_payload).encode('utf-8')
+                            )
+                            print(
+                                "[INFO] Started async rubric generation",
+                                {"requestId": aws_request_id, "questionHash": qhash},
+                            )
+                        except Exception as e:
+                            print(
+                                "[ERROR] Failed to invoke rubric generation",
+                                {"requestId": aws_request_id, "error": repr(e)},
+                            )
+                            # Continue anyway - rubric can be generated on-demand during judging
+                    
                     return _resp(
                         200,
                         {

--- a/backend/src/judge_answer/app.py
+++ b/backend/src/judge_answer/app.py
@@ -228,9 +228,20 @@ def lambda_handler(event, context):
         question_hash = question_id.strip()
 
         repo = QuizRepo(QUIZ_TABLE_NAME)
-        item = repo.get_by_hash(question_hash)
+        
+        # Rubric完成を待機して取得（最大15秒）
+        item = repo.get_by_hash_with_retry(question_hash, max_retries=5, wait_seconds=3.0)
+        
         if not item:
             raise AppError("NotFound", "Question not found", 404)
+        
+        # Rubricが未完成の場合はエラー
+        if not item.get("Rubric"):
+            raise AppError(
+                "RubricNotReady",
+                "採点基準がまだ準備中です。数秒後に再度お試しください。",
+                503
+            )
 
         rubric = item["Rubric"]
         question_body = item["Question"]["Body"]

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -195,14 +195,179 @@ Resources:
         - arm64
 
   # Bedrockのプロンプトマネジメント定義
+  
+  # クイズ問題文生成用プロンプト（title + body + tags）
+  QuizQuestionPrompt:
+    Type: AWS::Bedrock::Prompt
+    Properties:
+      Name: !Sub "${AWS::StackName}-quiz-question-prompt"
+      Description: "AWS quiz question generation prompt (title + body only)"
+      Variants:
+        - Name: "default"
+          ModelId: !Ref BedrockModelId
+          TemplateType: "CHAT"
+          InferenceConfiguration:
+            Text:
+              MaxTokens: 1000
+              Temperature: 0.15
+          TemplateConfiguration:
+            Chat:
+              InputVariables:
+                - Name: "category"
+                - Name: "level"
+                - Name: "avoid_duplicate_hint"
+                - Name: "question_style"
+                - Name: "style_guidance"
+                - Name: "source_context"
+              System:
+                - Text: |
+                    AWS教育用クイズ作成者。SOURCE_CONTEXTのみを根拠に、日本語で問題文を生成。
+                    
+                    【重要】出力形式:
+                    - 純粋なJSONオブジェクトのみ出力
+                    - コードフェンス(```)は絶対に使用禁止
+                    - {で始まり}で終わる
+                    
+                    【絶対禁止事項】:
+                    - 選択肢（A/B/C/D、1/2/3/4など）を含む問題は絶対禁止
+                    - 「どれ？」「どちら？」「次のうち」などの選択を促す表現は絶対禁止
+                    - YES/NO形式の問題は絶対禁止
+                    - 正誤判定（○×）形式の問題は絶対禁止
+                    
+                    【必須要件】:
+                    - SOURCE_CONTEXTにない事実は断定しない
+                    - level: 100=基礎、200=設計、300=実装、400=専門家
+                    - 必ず記述式で具体的な説明を求める問題にする
+                    - 「説明せよ」「答えよ」「述べよ」「列挙せよ」など記述を求める表現を使う
+                    - 複数の観点（①②③など）を答えさせる形式を推奨
+                    - 簡潔に書く（冗長な説明を避ける）
+                    - bodyは途中で切らず、必ず文を完結させる
+                    - 文面はジョークを効かせて、ユーモアな表現とする
+              Messages:
+                - Role: "user"
+                  Content:
+                    - Text: |
+                        category={{category}}, level={{level}}, style={{question_style}}
+                        
+                        【絶対禁止】:
+                        - A/B/C/D形式の選択肢を含めること
+                        - 「どれ？」「どちら？」「次のうち」などの選択を促す表現
+                        - YES/NO、○×などの二択問題
+                        
+                        【必須】:
+                        - 記述式で具体的な説明を求める問題文にする
+                        - 「①〜、②〜、③〜を説明せよ」のように複数観点を答えさせる形式を推奨
+                        - 「なぜ〜か説明せよ」「どのように〜か述べよ」など記述を求める
+                        
+                        制約（厳守）:
+                        - title≤80字, body≤300字, sourceSummary≤250字
+                        - 【重要】純粋なJSONのみ出力（```は絶対禁止）
+                        - 極力簡潔に（生成速度最優先）
+                        - bodyは必ず完結させる（途中で切らない）
+                        
+                        重複回避:
+                        {{avoid_duplicate_hint}}
+                        
+                        出題方針:
+                        {{style_guidance}}
+                        
+                        根拠:
+                        {{source_context}}
+                        
+                        【良い例】
+                        body: "新人エンジニアが「STSの一時認証情報は永続的に有効」と説明した。①この説明の誤り、②一時認証情報の正しい特性、③セキュリティ上の利点を説明せよ。"
+                        
+                        【悪い例（絶対禁止）】
+                        body: "この説明の誤りはどれでしょう？ A. 〜 B. 〜 C. 〜 D. 〜"
+                        
+                        【出力例】{で始まり}で終わる純粋なJSON:
+                        {"title":"","body":"","category":"","level":0,"sourceSummary":"","tags":[]}
+  
+  # Rubric生成用プロンプト
+  QuizRubricPrompt:
+    Type: AWS::Bedrock::Prompt
+    Properties:
+      Name: !Sub "${AWS::StackName}-quiz-rubric-prompt"
+      Description: "AWS quiz rubric generation prompt (scoring criteria)"
+      Variants:
+        - Name: "default"
+          ModelId: !Ref BedrockModelId
+          TemplateType: "CHAT"
+          InferenceConfiguration:
+            Text:
+              MaxTokens: 2000
+              Temperature: 0.15
+          TemplateConfiguration:
+            Chat:
+              InputVariables:
+                - Name: "category"
+                - Name: "level"
+                - Name: "title"
+                - Name: "body"
+                - Name: "source_context"
+              System:
+                - Text: |
+                    AWS教育用クイズの採点基準（rubric）作成者。
+                    
+                    【重要】出力形式:
+                    - 純粋なJSONオブジェクトのみ出力
+                    - コードフェンス(```)は絶対に使用禁止
+                    - {で始まり}で終わる
+                    
+                    必須ルール:
+                    - SOURCE_CONTEXTとQUESTIONに基づいて採点基準を作成
+                    - rubric必須（Must/Nice/Wrong/ScoringPolicy）
+                    - correct=100%、close=80%を満たすScoringPolicy
+                    - mustHavePointsは4〜6個
+                    - 記述式回答を前提とした採点基準を作成
+                    - 選択式（A/B/C/D）の採点基準は禁止
+                    
+                    【簡潔化ルール（重要）】:
+                    - label: 端的に（例: 「Governanceモードの削除可能性」）
+                    - notes: 採点の要点のみ（例: 「バイパス権限で削除可能と説明」）
+                    - 冗長な表現を避ける（「〜への言及」「〜の指摘」「〜しているか確認」など不要）
+                    - 文字数を最小限に（生成速度最優先）
+                    
+                    各ポイント構造（厳守）:
+                    - id: 文字列（p1, n1, w1など）
+                    - label: 文字列（40字以内、簡潔に）
+                    - keywords_any: 文字列の配列（各20字以内）
+                    - notes: 文字列（80字以内、要点のみ）
+              Messages:
+                - Role: "user"
+                  Content:
+                    - Text: |
+                        category={{category}}, level={{level}}
+                        
+                        【問題】
+                        title: {{title}}
+                        body: {{body}}
+                        
+                        制約（厳守）:
+                        - expectedAnswer≤400字
+                        - label≤40字（簡潔に）, notes≤80字（簡潔に）, keywords_any各≤20字
+                        - mustHavePointsは4〜6個
+                        - 【重要】純粋なJSONのみ出力（```は絶対禁止）
+                        - 記述式回答を前提とした採点基準を作成
+                        - 【重要】極力簡潔に（生成速度最優先、冗長な説明を避ける）
+                        - notesは採点の要点のみ記載（詳細な説明は不要）
+                        - labelは端的に（「〜への言及」「〜の指摘」など冗長な表現を避ける）
+                        
+                        根拠:
+                        {{source_context}}
+                        
+                        【出力例】{で始まり}で終わる純粋なJSON:
+                        {"expectedAnswer":"","mustHavePoints":[{"id":"p1","label":"","keywords_any":[""],"notes":""}],"niceToHavePoints":[{"id":"n1","label":"","keywords_any":[""],"notes":""}],"commonWrongClaims":[{"id":"w1","label":"","keywords_any":[""],"notes":""}],"scoringPolicy":{"correct_threshold":1.0,"close_threshold":0.8,"must_points_total":4,"close_if_must_points_met_at_least":3,"correct_if_must_points_met_at_least":4}}
+  
+  # 旧プロンプト（後方互換用、将来削除予定）
   QuizPrompt:
     Type: AWS::Bedrock::Prompt
     Properties:
       Name: !Sub "${AWS::StackName}-quiz-prompt"
-      Description: "AWS quiz generation prompt (managed)"
+      Description: "AWS quiz generation prompt (managed) - DEPRECATED"
       Variants:
         - Name: "default"
-          ModelId: !Ref BedrockModelId # ← 生成AIリソースは「モデル」
+          ModelId: !Ref BedrockModelId
           TemplateType: "CHAT"
           InferenceConfiguration:
             Text:
@@ -274,12 +439,26 @@ Resources:
       PromptArn: !GetAtt QuizPrompt.Arn
       Description: !GetAtt QuizPrompt.UpdatedAt # Prompt更新で差分が出て「最新version」が発行される
 
+  QuizQuestionPromptVersion:
+    Type: AWS::Bedrock::PromptVersion
+    Properties:
+      PromptArn: !GetAtt QuizQuestionPrompt.Arn
+      Description: !Sub "Updated at ${AWS::StackName} - No multiple choice"  # 強制的に新バージョン作成
+
+  QuizRubricPromptVersion:
+    Type: AWS::Bedrock::PromptVersion
+    Properties:
+      PromptArn: !GetAtt QuizRubricPrompt.Arn
+      Description: !Sub "Updated at ${AWS::StackName} - Concise rubric v2"  # 強制的に新バージョン作成
+
   GetNextQuizFunction:
     Type: AWS::Serverless::Function
     Properties:
       Environment:
         Variables:
           BEDROCK_PROMPT_ARN: !Ref QuizPromptVersion
+          BEDROCK_QUESTION_PROMPT_ARN: !Ref QuizQuestionPromptVersion
+          GENERATE_RUBRIC_FUNCTION_NAME: !Ref GenerateRubricFunction
       Handler: app.lambda_handler
       CodeUri: src/get_next_quiz/
       Timeout: 60
@@ -289,6 +468,8 @@ Resources:
       Policies:
         - DynamoDBCrudPolicy:
             TableName: !Ref QuizHistoryTable
+        - LambdaInvokePolicy:
+            FunctionName: !Ref GenerateRubricFunction
         - Statement:
             - Effect: Allow
               Action:
@@ -304,6 +485,30 @@ Resources:
             ApiId: !Ref QuizApi
             Path: /quiz/next
             Method: GET
+
+  GenerateRubricFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub "${AWS::StackName}-generate-rubric"
+      Handler: app.lambda_handler
+      CodeUri: src/generate_rubric/
+      Timeout: 30
+      MemorySize: 512
+      Layers:
+        - !Ref CommonLayer
+      Environment:
+        Variables:
+          BEDROCK_RUBRIC_PROMPT_ARN: !Ref QuizRubricPromptVersion
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: !Ref QuizHistoryTable
+        - Statement:
+            - Effect: Allow
+              Action:
+                - bedrock:InvokeModel
+                - bedrock:RenderPrompt
+                - bedrock:ApplyGuardrail
+              Resource: "*"
 
   StartQuizGenerationFunction:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
変更ファイルと修正概要

- backend/template.yaml
  - QuizQuestionPrompt 追加（title+body生成用、MaxTokens: 1000）
  - QuizRubricPrompt 追加（rubric生成用、MaxTokens: 2500）
  - GenerateRubricFunction 追加（rubric生成専用Lambda）
  - 環境変数とIAM権限追加

- backend/src/generate_rubric/app.py (新規)
  - Rubric生成専用関数
  - Bedrock呼び出し → DDB更新

- backend/src/get_next_quiz/app.py
  - title+bodyのみ生成に変更
  - 非同期でGenerateRubricFunction呼び出し
  - レスポンス時間短縮（22秒 → 12秒目標）

- backend/src/judge_answer/app.py
  - Rubric完成待機ロジック追加（最大15秒）

- backend/layers/common/python/common/ddb.py
  - update_rubric() メソッド追加
  - get_by_hash_with_retry() メソッド追加

- backend/layers/common/python/common/validate.py
  - validate_rubric() 関数追加